### PR TITLE
Don't forbid sending addr-reg option if M=O=0

### DIFF
--- a/draft-ietf-dhc-addr-notification.md
+++ b/draft-ietf-dhc-addr-notification.md
@@ -230,7 +230,7 @@ The client MUST generate a transaction ID and insert this value in the "transact
 The client MUST only send the ADDR-REG-INFORM message for valid ({{!RFC4862}}) addresses of global scope ({{!RFC4007}}).
 The client MUST NOT send the  ADDR-REG-INFORM message for addresses configured by DHCPv6.
 
-The client MUST NOT send the ADDR-REG-INFORM message if it has not received any Router Advertisement message with either M or O flags set to 1.
+The client SHOULD NOT send the ADDR-REG-INFORM message if it has not received any Router Advertisement message with either M or O flags set to 1.
 
 After receiving this ADDR-REG-INFORM message, the address registration server SHOULD verify that the address being registered is "appropriate to the link" as defined by [RFC8415]. If the server believes that  address being registered is not appropriate to the link [RFC8415], it MUST drop the message, and SHOULD log this fact. If the address is appropriate, the server:
 


### PR DESCRIPTION
This may be useful in the future to inform the network of the device's hostname on networks that don't have DHCPv4 or DHCPv6 servers.

On such networks, setting M=1 or O=1 might confuse clients by making them think that there is a DHCPv6 server. Those clients might, for example, refuse to connect to the network, or time out, if their DHCPv6 requests do not receive a response.