### PR TITLE
IETF118 comments

### DIFF
--- a/draft-ietf-dhc-addr-notification.md
+++ b/draft-ietf-dhc-addr-notification.md
@@ -125,7 +125,7 @@ This document provides a mechanism for a device to inform the DHCPv6 server that
 # Registration Mechanism Overview
 
 The DHCPv6 protocol is used as the address registration protocol when a DHCPv6 server performs the role of an address registration server.
-This document introduces a new Address Registration (OPTION_ADDRESS_REG_ENABLE) option which indicates that the server supports the registration mechanism.
+This document introduces a new Address Registration (OPTION_ADDR_REG_ENABLE) option which indicates that the server supports the registration mechanism.
 Before registering any addresses, the client sends an Information-Request message and includes the Address Registration option code
 into the Option Request option (see Section 21.7 of {{!RFC8415}}).
 If the server supports the address registration, it includes an Address Registration option into its Reply message.
@@ -150,13 +150,13 @@ The address registration mechanism overview is shown in Fig.1.
     | -------------------------------------------->  |
     |    INFORMATION-REQUEST MESSAGE                 |
     |       - OPTION-REQUEST OPTION                  |
-    |          -- OPTION_ADDRESS_REG_ENABLE code     |
+    |          -- OPTION_ADDR_REG_ENABLE code     |
     |                                                |
     |                                                |
     |                                                |
     |<---------------------------------------------  |
     |     REPLY MESSAGE                              |
-    |       - ADDR_REG_ENABLE OPTION                 |
+    |       - OPTION_ADDR_REG_ENABLE                 |
     |                                                |
     |                                                |
     |  src: address being registered                 |
@@ -178,7 +178,7 @@ Figure 1: Address Registration Procedure Overview
 
 ## DHCPv6 Address Registration Option
 
-The DHCPv6 server includes an Address Registration option (OPTION_ADDR_REG) to indicate that the server supports the mechanism described in this document.
+The DHCPv6 server includes an Address Registration option (OPTION_ADDR_REG_ENABLE) to indicate that the server supports the mechanism described in this document.
 The format of the Address Registration option is described as follows:
 
 
@@ -188,7 +188,7 @@ The format of the Address Registration option is described as follows:
      |          option-code          |           option-len          |
      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
-     option-code           OPTION_ADDR_REG (TBA0)
+     option-code           OPTION_ADDR_REG_ENABLE (TBA0)
 
      option-len            0
 
@@ -377,7 +377,7 @@ In particular, the ADDR-REG-INFORM message MUST not be used for authentication a
 
 This document introduces the following new entities which require an allocation out of the DHCPv6 registries defined at http://www.iana.org/assignments/dhcpv6-parameters/:
 
-*   one new DHCPv6 option (OPTION_ADDR_REG, TBA0, described in Section 4.1) which requires an allocation out of the registry of DHCPv6 Option Codes.
+*   one new DHCPv6 option (OPTION_ADDR_REG_ENABLE, TBA0, described in Section 4.1) which requires an allocation out of the registry of DHCPv6 Option Codes.
 *   two new DHCPv6 messages which require an allocation out of the registry of Message Types:
     *  ADDR-REG-INFORM message (TBA1) described in Section 4.2
     *  ADDR-REG-REPLY (TBA2) described in Section 4.3.

--- a/draft-ietf-dhc-addr-notification.md
+++ b/draft-ietf-dhc-addr-notification.md
@@ -377,7 +377,11 @@ In particular, the ADDR-REG-INFORM message MUST not be used for authentication a
 
 This document introduces the following new entities which require an allocation out of the DHCPv6 registries defined at http://www.iana.org/assignments/dhcpv6-parameters/:
 
-*   one new DHCPv6 option (OPTION_ADDR_REG_ENABLE, TBA0, described in Section 4.1) which requires an allocation out of the registry of DHCPv6 Option Codes.
+*   one new DHCPv6 option, described in Section 4.1 which requires an allocation out of the registry of DHCPv6 Option Codes:
+    * Value: TBA0
+    * Description: OPTION_ADDR_REG_ENABLE
+    * Client ORO: Yes
+    * Singleton Option: Yes
 *   two new DHCPv6 messages which require an allocation out of the registry of Message Types:
     *  ADDR-REG-INFORM message (TBA1) described in Section 4.2
     *  ADDR-REG-REPLY (TBA2) described in Section 4.3.

--- a/draft-ietf-dhc-addr-notification.md
+++ b/draft-ietf-dhc-addr-notification.md
@@ -253,7 +253,7 @@ Servers MUST discard any ADDR-REG-INFORM messages that meet any of the following
 - the message does not include the IA Address option, or the IP address in the IA Address option does not match the source address of the original ADDR-REG-INFORM message sent by the client. The source address of the original message is the source IP address of the packet if it is not relayed, or the Peer-Address field of the innermost Relay-Forward message if it is relayed.
 - the message includes an Option Request Option.
 
-If the message is not discarded, the address registration server SHOULD verify that the address being registered is "appropriate to the link" as defined by [RFC8415]. If the server believes that the address being registered is not appropriate to the link, it MUST drop the message, and SHOULD log this fact. Otherwise, the server:
+If the message is not discarded, the address registration server SHOULD verify that the address being registered is "appropriate to the link" as defined by [RFC8415] or within a prefix delegated to the client. Otherwise, it MUST drop the message, and SHOULD log this fact. Otherwise, the server:
 
 *    SHOULD register or update a binding between the provided Client Identifier and IPv6 address in its database. The lifetime of the binding is equal to the Valid Lifetime of the address reported by the client. If there is already a binding between the registered address and another another client, the server SHOULD log the fact and update the binding.
 *    SHOULD log the address registration information (as is done normally for clients to which it has assigned an address), unless configured not to do so.

--- a/draft-ietf-dhc-addr-notification.md
+++ b/draft-ietf-dhc-addr-notification.md
@@ -307,15 +307,25 @@ The ADDR-REG-REPLY message only indicates that the ADDR-REG-INFORM message has b
 ## Address Registration Support Signalling
 
 To ensure that ADDR-REG-INFORM messages are only sent if there is at least one DHCPv6 server which supports the address registration mechanism, the client SHOULD send an Information-Request message when connecting to the network and performing IPv6 interface configuration.
+If the Reply messages received in response contain an Address Registration option, the client starts sending Registration Request messages as described above.
+
 After that, the client transmits periodic Information-request messages as per Section 18.2.6 of {{!RFC8415}}.
 An Option Request option contained in that Information-Request message (see Section 18.1.5 of {{!RFC8415}}) MUST contain an Address Registration option code.
 
-If no Reply messages received in response contain an Address Registration option, the client MUST NOT send any ADDR-REG-INFORM messages. If at least one Reply contains an Address Registration option, the client SHOULD start sending ADDR-REG-INFORM messages as described in this document.
+If Reply messages received in response to an Information-request message does not contain an Address Registration option, the client MUST NOT send any ADDR-REG-INFORM messages.
 
 When the client received an Address Registration option in an earlier Reply, then sends an Information-request and
 the Address Registration option is not not present in the Reply, the client MUST stop sending ADDR-REG-INFORM messages
 (see Section 18.2.10 of {{!RFC8415}}).
 
+ {{!RFC8415}} does not specify the client behaviour if the Reply messages received from different servers contain conflicting information (for example, one Reply contain OPTION_ADDR_REG_ENABLE option and another does not).
+If there are multiple DHCPv6 servers on the network, it is possible that only some of those servers support the address registration mechanism, while other servers do not.
+In such networks, every time the client sends an Information-Request message, the client might be oscillating between starting and stopping address registration, depending on the order in which Reply messages are received. As a result, if some servers support the registration mechanism while other don't:
+
+*   the registration mechanism is not reliable (as the client might stop it upon receiving a Reply without the OPTION_ADDR_REG_ENABLE option.
+*   the servers which do not support the registration will still be receiving Registration Request messages (and drop them).
+
+Such configuration can exist during incremental rollout of the registration mechanism support across the DHCPv6 infrastructure and is NOT RECOMMENDED long-term.
 
 ## Retransmission
 

--- a/draft-ietf-dhc-addr-notification.md
+++ b/draft-ietf-dhc-addr-notification.md
@@ -150,7 +150,7 @@ The address registration mechanism overview is shown in Fig.1.
     | -------------------------------------------->  |
     |    INFORMATION-REQUEST MESSAGE                 |
     |       - OPTION-REQUEST OPTION                  |
-    |          -- OPTION_ADDR_REG_ENABLE code     |
+    |          -- OPTION_ADDR_REG_ENABLE code        |
     |                                                |
     |                                                |
     |                                                |


### PR DESCRIPTION
0. Fixing inconsistent option name
1. Addressing IANA comments (adding option attributes).
2. Clarifying inconsistent replies from servers
3. Allowing the server to accept registration from delegated prefixes.